### PR TITLE
feat: 2 grid fcns walk array and call each other recursively to rende…

### DIFF
--- a/NewDef.php
+++ b/NewDef.php
@@ -62,7 +62,7 @@ echo "
                     'Status' => [
                         "label" => "<label for='Status' class='required'>Status</label>",
                         "tagName" => "select",
-                        "element" => "<select name='SpecLoc' id='SpecLoc' class='form-control' required>%s</select>",
+                        "element" => "<select name='Status' id='Status' class='form-control' required>%s</select>",
                         "type" => null,
                         "name" => 'Status',
                         "id" => 'Status',

--- a/RecDef.php
+++ b/RecDef.php
@@ -101,31 +101,19 @@ if ($stmt = $link->prepare($sql)) {
           }
         }
       }
+      $link->close();
+      header("Location: ViewDef.php?defID=$newDefID");
     } elseif ($stmt->error) {
-      echo "<pre style='color: mediumSlateBlue; font-size: 1.2rem'>STATEMENT ERROR: ";
-      echo $stmt->error;
-      echo "</pre>";
+      $stmt->close();
+      printSqlErrorAndExit($link, $sql);
     } else {
-      echo "<pre style='color: goldenRod; font-size: 1.2rem'>LINK ERROR from execute: ";
-      echo $link->error;
-      echo "</pre>";
+      $stmt->close();
+      printSqlErrorAndExit($link, $sql);
     }
     // echo "<h4>did it execute? what was the result? who knows?</h4>";
   } else {
-    echo "<pre style='color: limeGreen'>";
-    echo $link->error;
-    echo "</pre>";
-    $link->close();
-    exit;
+    printSqlErrorAndExit($link, $sql);
   }
 } else {
-  echo "<pre style='color: fuchsia'>{$link->error}</pre>";
-  $link->close();
-  exit;
+  printSqlErrorAndExit($link, $sql);
 }
-  
-// $stmt->close();
-$link->close();
-	
-header("Location: ViewDef.php?defID=$newDefID");
-?>

--- a/ViewDef.php
+++ b/ViewDef.php
@@ -29,6 +29,14 @@ function returnFakeInputStr($val) {
     return returnHtmlForVal($val, $str, $altStr);
 }
 
+function iterateRows(array $rowGroup, $title) {
+    print "<h5 class='grey-bg pad'>$title</h5>";
+    foreach ($rowGroup as $row) {
+        $options = count($row) === 1 ? ['colWd' => 6] : [];
+        print returnRow($row, $options);
+    }
+}
+
 if ($defID) {
     $sql = file_get_contents("ViewDef.sql").$defID;
     
@@ -63,6 +71,7 @@ if ($defID) {
                 $defType);  
         while ($stmt->fetch()) {
             $requiredRows = [
+                'Required Information',
                 [
                     sprintf($labelStr, 'Safety Certifiable'),
                     sprintf($fakeInputStr, $SafetyCert),
@@ -105,6 +114,7 @@ if ($defID) {
             ];
             
             $optionalRows = [
+                'Optional Information',
                 [
                     sprintf($labelStr, 'Spec or Code'),
                     returnFakeInputStr(stripcslashes($Spec)),
@@ -119,6 +129,7 @@ if ($defID) {
             ];
             
             $closureRows = [
+                'Clouser Information',
                 [
                     sprintf($labelStr, 'Evidence Type'),
                     returnFakeInputStr($EvidenceType),
@@ -133,6 +144,7 @@ if ($defID) {
             ];
             
             $modHistory = [
+                'Modification History',
                 [
                     sprintf($labelStr, 'Date Created'),
                     sprintf($labelStr, $DateCreated),
@@ -156,32 +168,32 @@ if ($defID) {
                 <header class='container page-header'>
                     <h1 class='page-title $color pad'>Deficiency No. $defID</h1>
                 </header>
-                <main class='container main-content'>
-                    <div class='row'>
-                        <div class='col-12'>
-                            <h5 class='grey-bg pad'>Required Information</h5>
-                        </div>
-                    </div>";
-                    foreach ($requiredRows as $gridRow) {
-                        $options = count($gridRow) === 1 ? ['colWd' => 6] : [];
-                        print returnRow($gridRow, $options);
+                <main class='container main-content'>";
+                    foreach ([$requiredRows, $optionalRows, $closureRows, $modHistory] as $rowGroup) {
+                        $rowName = array_shift($rowGroup);
+                        iterateRows($rowGroup, $rowName);
                     }
-                    print "<h5 class='grey-bg pad'>Optional Information</h5>";
-                    foreach ($optionalRows as $gridRow) {
-                        $options = count($gridRow) === 1 ? ['colWd' => 6] : [];
-                        print returnRow($gridRow, $options);
-                    }
-                    print "<h5 class='grey-bg pad'>Closure Information</h5>";
-                    foreach ($closureRows as $gridRow) {
-                        $options = count($gridRow) === 1 ? ['colWd' => 6] : [];
-                        print returnRow($gridRow, $options);
-                    }
-                    print "<h5 class='grey-bg pad'>Modification Details</h5>";
-                    foreach ($modHistory as $gridRow) {
-                        $options = count($gridRow) === 1 ? ['colWd' => 6] : [];
-                        print returnRow($gridRow, $options);
-                    }
-                            
+                    // iterateRows($requiredRows, 'Required Information');
+                    // <h5 class='grey-bg pad'>Required Information</h5>";
+                    // foreach ($requiredRows as $gridRow) {
+                    //     $options = count($gridRow) === 1 ? ['colWd' => 6] : [];
+                    //     print returnRow($gridRow, $options);
+                    // }
+                    // print "<h5 class='grey-bg pad'>Optional Information</h5>";
+                    // foreach ($optionalRows as $gridRow) {
+                    //     $options = count($gridRow) === 1 ? ['colWd' => 6] : [];
+                    //     print returnRow($gridRow, $options);
+                    // }
+                    // print "<h5 class='grey-bg pad'>Closure Information</h5>";
+                    // foreach ($closureRows as $gridRow) {
+                    //     $options = count($gridRow) === 1 ? ['colWd' => 6] : [];
+                    //     print returnRow($gridRow, $options);
+                    // }
+                    // print "<h5 class='grey-bg pad'>Modification Details</h5>";
+                    // foreach ($modHistory as $gridRow) {
+                    //     $options = count($gridRow) === 1 ? ['colWd' => 6] : [];
+                    //     print returnRow($gridRow, $options);
+                    // }
         }
         $stmt->close();
         

--- a/html_functions/bootstrapGrid.php
+++ b/html_functions/bootstrapGrid.php
@@ -1,24 +1,64 @@
 <?php
 require_once 'htmlForms.php';
+require_once 'utils/utils.php';
+
+function isElementArray(array $el) {
+    return isset($el['element'])
+        || isset($el['tagName'])
+        || isset($el['label']);
+}
+
+function isFormCtrl(array $el) {
+    return $el['tagName'] === 'select'
+        || $el['tagName'] === 'input'
+        || $el['tagName'] === 'textarea';
+}
+
+function ifOptionsExtract(array &$el, array &$opts) {
+    if (isset($el['options'])) {
+        $opts = $opts + $el['options']; // but which one should take precendence??
+        unset($el['options']);
+    }
+}
 /*
 ** available options at this point are:
 ** 'inline'
 ** 'colWd'
 ** 'offset'
 */
-// this function should receive a complete element string unless it's a select element that needs iterating over
 function returnCol($element, $wd, $options = []) {
     $colStr = "<div class='col-md-%s'>%s</div>";
-    $wd = isset($options['offset']) ? $wd." offset-md-{$options['offset']}" : $wd;
+    $wd = $wd ? $wd : 12;
+    isset($options['offset']) && $wd .= " offset-md-{$options['offset']}";
     if (is_array($element)) {
-        $isFormCtrl = $element['tagName'] === 'select'
-            || $element['tagName'] === 'input'
-            || $element['tagName'] === 'textarea';
-        $content = $isFormCtrl
-            ? isset($options['inline'])
-                ? returnRow([ $element['label'], returnFormCtrl($element) ])
-                : $element['label'].returnFormCtrl($element)
-            : returnRow($element);
+        // right here I need to test for whether $element is a collection of $elements or a singular $element array
+        // if it's a singular element array then I can pass it to the relevant fcn (formCtrl or returnRow)
+        // if it's a collection I need to iterate it, passing each element to returnRow
+        if (isElementArray($element)) {
+            if (isFormCtrl($element)) {
+                $label = isset($element['label']) ? $element['label'] : '';
+                if (isset($options['inline']) && $options['inline']) {
+                    if (isset($element['type']) && $element['type'] === 'checkbox') {
+                        $container = "<div class='form-check form-check-inline'>%s</div>";
+                        $content = sprintf($container, $label.returnFormCtrl($element));
+                    } else $content = returnRow([ $label, returnFormCtrl($element) ]);
+                } else $content = $label.returnFormCtrl($element);
+            } elseif (isset($element['element']) && $element['element']) {
+                $content = $element['element'];
+            } else $content = $element[0];
+            // $content = isFormCtrl($element)
+            //     ? (isset($options['inline'])
+            //         ? returnRow([ $element['label'], returnFormCtrl($element) ])
+            //         : $element['label'].returnFormCtrl($element))
+            //     : (isset($element['element'])
+            //         ? $element['element']
+            //         : $element[0]);
+        } else {
+            $content = '';
+            foreach ($element as $el) {
+                $content .= returnRow($el, $options);
+            }
+        }
         $col = sprintf($colStr, $wd, $content);
     } elseif (is_string($element)) {
         $col = sprintf($colStr, $wd, $element);
@@ -26,21 +66,55 @@ function returnCol($element, $wd, $options = []) {
     return $col;
 }
 
-function returnRow($elements, $options = []) {
-    $elRow = "<div class='row item-margin-bottom'>";
+function returnRow(array $elements, $options = []) {
+    // if options rolled into $elements, extract it
+    ifOptionsExtract($elements, $options);
+    // print "<p class='text-yellow' style='font-size: .6rem'>";
+    // var_dump($options);
+    // print "</p>";
+    
+    $elRow = "<div class='row item-margin-bottom'>%s</div>";
+    $colCollection = '';
     $numEls = count($elements);
-    // if number of elements don't divide evenly by 12 substract out the remainder
+    
+    $purpleStar = "<span style='color: purple'>✳</span>";
+    $yellowStar = "<span style='color: goldenRod'>✳</span>";
+    
+    // if number of elements doesn't divide evenly by 12 take the remainder
     // this number will be added to the last col
     $extraCols = 12 % $numEls;
-    $colWd = 12 / ($numEls - $extraCols);
+    $colWd = floor(12 / $numEls);
     // if row is singular and has a specific wd, pass it and its wd to returnCol without looping
-    if (count($elements) === 1 && isset($options['colWd'])) {
-        $offset = floor((12 - $options['colWd'])/2);
-        $elRow .= returnCol(array_shift($elements), $options['colWd'], ['offset' => $offset]);
-    } else foreach ($elements as $el) {
-        $elRow .= returnCol($el, $colWd, $options);
+    if ($numEls === 1) {
+        $el = array_shift($elements);
+        is_array($el) && ifOptionsExtract($el, $options);
+        // check if colWd option is present
+        // option on column takes precendence if given
+        isset($options['colWd']) && $colWd = $options['colWd'];
+        isset($el['options']['colWd']) && $colWd = $el['options']['colWd'];
+        
+        $options['offset'] = isset($options['offset'])
+            ? $options['offset']
+            : (int) floor(12 - $colWd)/2;
+            
+        $colCollection .= returnCol($el, $colWd, $options);
+    } else {
+        // if you're iterating you'll need a counter
+        $i = 1;
+        foreach ($elements as $el) {
+            // write options to a new var so as not to preserve options from prev col
+            $colOpts = $options;
+            is_array($el) && ifOptionsExtract($el, $colOpts);
+            
+            // print "<h4 class='text-primary' style='font-size: .5rem'>";
+            // var_dump($options);
+            // print "</h4>";
+            
+            $colWd = $i === $numEls ? $colWd + $extraCols : $colWd;
+            $colCollection .= returnCol($el, $colWd, $colOpts);
+            $i++;
+        }
     }
-    $elRow .= "</div>";
-    return $elRow;
+    return sprintf($elRow, $colCollection);
 }
 ?>

--- a/html_functions/htmlFuncs.php
+++ b/html_functions/htmlFuncs.php
@@ -12,4 +12,8 @@ function returnClassList($arrVal) {
     elseif (is_array($arrVal)) $classList = " class='".implode(' ', $arrVal)."'";
     return $classList;
 }
+
+function returnHtmlFromArray(array $htmlArr) {
+    // placeholder
+}
 ?>

--- a/newBartDef.php
+++ b/newBartDef.php
@@ -16,7 +16,6 @@ if ($result = $link->query('SELECT bdPermit from users_enc where userID='.$_SESS
 if ($bdPermit) {
     $labelStr = "<label for='%s'%s>%s</label>";
     $required = " class='required'";
-    $checkboxRequired = " class='form-check-label mr-2 required'";
     
     $topFields = [
         [
@@ -121,24 +120,30 @@ if ($bdPermit) {
                     'element' => "<input name='bdAttachments' id='bdAttachments' type='file' class='form-control' disabled>"
                 ]
             ]),
-            returnRow([
-                [
-                    'label' => "<label for='bdCommText'>Comment</label>",
-                    'tagName' => 'textarea',
-                    'element' => "<textarea name='bdCommText' id='bdCommText' class='form-control'>%s</textarea>",
-                    'value' => ''
+            'col2' => [
+                'row1' => [
+                    'bdCommText' => [
+                        'label' => "<label for='bdCommText'>Add comment</label>",
+                        'tagName' => 'textarea',
+                        'element' => "<textarea name='bdCommText' id='bdCommText' class='form-control'>%s</textarea>",
+                    ]
+                ],
+                'row2' => [
+                    'options' => [ 'inline' => true ],
+                    'resolution_disputed' => [
+                        'label' => "<label for='resolution_disputed' class='form-check-label check-label-left'>Resolution disputed</label>",
+                        'tagName' => 'input',
+                        'type' => 'checkbox',
+                        'element' => "<input name='resolution_disputed' id='resolution_disputed' type='checkbox' value='1' class='form-check-input' %s>",
+                    ],
+                    'structural' => [
+                        'label' => "<label for='structural' class='form-check-label check-label-left'>Stuctural</label>",
+                        'tagName' => 'input',
+                        'type' => 'checkbox',
+                        'element' => "<input name='structural' id='structural' type='checkbox' value='1' class='form-check-input' %s>",
+                    ]
                 ]
-            ]).// comments will need sep table
-            returnRow([
-                "<div class='form-check form-check-inline'>"
-                    .sprintf($labelStr, 'resolution_disputed', '', 'Resolution disputed')
-                    ."<input name='resolution_disputed' id='resolution_disputed' type='checkbox' value='1' class='form-check-input'>
-                </div>",
-                "<div class='form-check form-check-inline'>"
-                    .sprintf($labelStr, 'structural', '', 'Structural')
-                    ."<input name='structural' id='structural' type='checkbox' value='1' class='form-check-input'>
-                </div>"
-            ])
+            ]
         ]
     ];
 

--- a/styles2.css
+++ b/styles2.css
@@ -628,6 +628,10 @@ a.nav-cur-page:hover, button.nav-cur-page:hover {
     margin: 0;
 }
 
+.check-label-left {
+    margin-right: .3125rem;
+}
+
 .form-control.subtle {
     box-shadow: none;
     outline: none;

--- a/updateBartDef.php
+++ b/updateBartDef.php
@@ -32,14 +32,18 @@ if ($stmt = $link->prepare($sql)) {
         if ($result = stmtBindResultArray($stmt)[0]) {
             $labelStr = "<label for='%s'%s>%s</label>";
             $required = " class='required'";
-            $checkboxRequired = " class='form-check-label mr-2 required'";
             $commentFormat = "
                 <div class='thin-grey-border pad mb-3'>
                     <h6 class='d-flex flex-row justify-content-between text-secondary'><span>%s</span><span>%s</span></h6>
                     <p>%s</p>
                 </div>";
 
-            
+            function returnLabel($for, $text, $required = '', $str = "<label for='%s'%s>%s</label>") {
+                $required && $requiredAttr = " class='required'";
+                return sprintf($str, $for, $requiredAttr, $text);
+            }
+
+
             $stmt->close();
             
             // query for comments associated with this Def
@@ -61,34 +65,37 @@ if ($stmt = $link->prepare($sql)) {
             $stmt->close();
             
             $topFields = [
-                [
-                    returnRow([
-                        sprintf($labelStr, 'creator', $required, 'Creator'),
+                'row1' => [
+                    'col1' => [
+                        'options' => [ 'inline' => true ],
                         [
-                            'tagName' => 'select',
-                            'element' => "<select name='creator' id='creator' class='form-control' required>%s</select>",
-                            'value' => $result['creator'],
-                            'query' => "SELECT partyID, partyName from bdParties WHERE partyName <> '' ORDER BY partyID"
-                        ]
-                    ]).
-                    returnRow([
-                       sprintf($labelStr, 'next_step', '', 'Next step'),
+                            [
+                                'label' => returnLabel('creator', 'Creator', 'required'),
+                                'tagName' => 'select',
+                                'element' => "<select name='creator' id='creator' class='form-control' required>%s</select>",
+                                'value' => $result['creator'],
+                                'query' => "SELECT partyID, partyName from bdParties WHERE partyName <> '' ORDER BY partyID"
+                            ]
+                        ],
                         [
-                            'tagName' => 'select',
-                            'element' => "<select name='next_step' id='next_step' class='form-control'>%s</select>",
-                            'query' => 'SELECT bdNextStepID, nextStepName FROM bdNextStep ORDER BY bdNextStepID',
-                            'value' => $result['next_step']
-                        ]
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'bic', '', 'Ball in court'),
+                            [
+                                'label' => returnLabel('next_step', 'Next step'),
+                                'tagName' => 'select',
+                                'element' => "<select name='next_step' id='next_step' class='form-control'>%s</select>",
+                                'query' => 'SELECT bdNextStepID, nextStepName FROM bdNextStep ORDER BY bdNextStepID',
+                                'value' => $result['next_step']
+                            ]
+                        ],
                         [
-                            'tagName' => 'select',
-                            'element' => "<select name='bic' id='bic' class='form-control'>%s</select>",
-                            'query' => "SELECT partyID, partyName from bdParties WHERE partyName <> '' ORDER BY partyID",
-                            'value' => $result['bic']
+                            [
+                                'label' => returnLabel('bic', 'Ball in court'),
+                                'tagName' => 'select',
+                                'element' => "<select name='bic' id='bic' class='form-control'>%s</select>",
+                                'query' => "SELECT partyID, partyName from bdParties WHERE partyName <> '' ORDER BY partyID",
+                                'value' => $result['bic']
+                            ]
                         ]
-                    ]),
+                    ],
                     'descriptive_title_vta' => [
                         'label' => sprintf($labelStr, 'descriptive_title_vta', $required, 'Description'),
                         'tagName' => 'textarea',
@@ -99,7 +106,7 @@ if ($stmt = $link->prepare($sql)) {
             ];
         
             $vtaFields = [
-                [
+                'row1' => [
                     'root_prob_vta' => [
                         'label' => sprintf($labelStr, 'root_prob_vta', $required, 'Root problem'),
                         'tagName' => 'textarea',
@@ -107,7 +114,7 @@ if ($stmt = $link->prepare($sql)) {
                         'query' => null
                     ]
                 ],
-                [
+                'row2' => [
                     'resolution_vta' => [
                         'label' => sprintf($labelStr, 'resolution_vta', $required, 'Resolution'),
                         'tagName' => 'textarea',
@@ -115,128 +122,175 @@ if ($stmt = $link->prepare($sql)) {
                         'query' => null
                     ]
                 ],
-                [
-                    returnRow([
-                        sprintf($labelStr, 'status_vta', $required, 'Status'),
-                        [
-                            'tagName' => 'select',
-                            'element' => "<select name='status_vta' id='status_vta' class='form-control' required>%s</select>",
-                            'value' => $result['status_vta'],
-                            'query' => "SELECT statusID, status from Status WHERE status <> 'Deleted'"
-                        ]
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'priority_vta', $required, 'Priority'),
-                        [
-                            'tagName' => 'select',
-                            'element' => "<select name='priority_vta' id='priority_vta' class='form-control required>%s</select>",
-                            'value' => $result['priority_vta'],
-                            'query' => [ 1, 2, 3 ]
-                        ]
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'agree_vta', $required, 'Agree'),
-                        [
-                            'tagName' => 'select',
-                            'element' => "<select name='agree_vta' id='agree_vta' class='form-control' required>%s</select>",
-                            'value' => $result['agree_vta'],
-                            'query' => "SELECT agreeDisagreeID, agreeDisagreeName FROM agreeDisagree WHERE agreeDisagreeName <> ''"
-                        ]
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'safety_cert_vta', $required, 'Safety Certiable'),
-                        [
-                            'tagName' => 'select',
-                            'element' => "<select name='safety_cert_vta' id='safety_cert_vta' class='form-control'>%s</select>",
-                            'value' => $result['safety_cert_vta'],
-                            'query' => 'SELECT yesNoID, yesNo from YesNo'
-                        ]
-                    ]).
-                    returnRow([ // will need sep table
-                        "<label for='bdAttachments'>Upload attachment</label>",
-                        [
-                            'tagName' => 'input',
-                            'type' => 'file',
-                            'element' => "<input name='bdAttachments' id='bdAttachments' type='file' class='form-control' disabled>"
-                        ]
-                    ]),
-                    returnRow([
-                        [
-                            'label' => "<label for='bdCommText'>Add comment</label>",
-                            'tagName' => 'textarea',
-                            'element' => "<textarea name='bdCommText' id='bdCommText' class='form-control'>%s</textarea>",
-                            'value' => ''
-                        ]
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'resolution_disputed', '', 'Resolution disputed'),
-                        'resolution_disputed' => [
-                            'tagName' => 'input',
-                            'type' => 'checkbox',
-                            'element' => "<input name='resolution_disputed' id='resolution_disputed' type='checkbox' value='1' class='form-check-input' %s>",
-                            'value' => $result['resolution_disputed'],
-                            'query' => null
+                'row3' => [
+                    'col1' => [
+                        'options' => [ 'inline' => true ],
+                        'row1' => [
+                            [
+                                'label' => "<label for='status_vta'>Status</label>",
+                                'tagName' => 'select',
+                                'element' => "<select name='status_vta' id='status_vta' class='form-control' required>%s</select>",
+                                'value' => $result['status_vta'],
+                                'query' => "SELECT statusID, status from Status WHERE status <> 'Deleted'"
+                            ]
                         ],
-                        sprintf($labelStr, 'structural', '', 'Structural'),
-                        'structural' => [
-                            'tagName' => 'input',
-                            'type' => 'checkbox',
-                            'element' => "<input name='structural' id='structural' type='checkbox' value='1' class='form-check-input' %s>",
-                            'value' => $result['structural'],
-                            'query' => null
+                        'row2' => [
+                            [
+                                'label' => "<label for='priority_vta'>Priority</label>",
+                                'tagName' => 'select',
+                                'element' => "<select name='priority_vta' id='priority_vta' class='form-control required>%s</select>",
+                                'value' => $result['priority_vta'],
+                                'query' => [ 1, 2, 3 ]
+                            ]
+                        ],
+                        'row3' => [
+                            [
+                                'label' => "<label for='agree_vta'>Agree</label>",
+                                'tagName' => 'select',
+                                'element' => "<select name='agree_vta' id='agree_vta' class='form-control' required>%s</select>",
+                                'value' => $result['agree_vta'],
+                                'query' => "SELECT agreeDisagreeID, agreeDisagreeName FROM agreeDisagree WHERE agreeDisagreeName <> ''"
+                            ]
+                        ],
+                        'row4' => [
+                            [
+                                'label' => "<label for='safety_cert_vta'>Safety Certiable</label>",
+                                'tagName' => 'select',
+                                'element' => "<select name='safety_cert_vta' id='safety_cert_vta' class='form-control'>%s</select>",
+                                'value' => $result['safety_cert_vta'],
+                                'query' => 'SELECT yesNoID, yesNo from YesNo'
+                            ]
+                        ],
+                        'row5' => [ // will need sep table
+                            [
+                                'label' => "<label for='bdAttachments'>Upload attachment</label>",
+                                'tagName' => 'input',
+                                'type' => 'file',
+                                'element' => "<input name='bdAttachments' id='bdAttachments' type='file' class='form-control' disabled>"
+                            ]
                         ]
-                    ])
+                    ],
+                    'col2' => [
+                        'row1' => [
+                            'bdCommText' => [
+                                'label' => "<label for='bdCommText'>Add comment</label>",
+                                'tagName' => 'textarea',
+                                'element' => "<textarea name='bdCommText' id='bdCommText' class='form-control'>%s</textarea>",
+                                'value' => ''
+                            ]
+                        ],
+                        'row2' => [
+                            'options' => [ 'inline' => true ],
+                            'resolution_disputed' => [
+                                'label' => "<label for='resolution_disputed' class='form-check-label check-label-left'>Resolution disputed</label>",
+                                'tagName' => 'input',
+                                'type' => 'checkbox',
+                                'element' => "<input name='resolution_disputed' id='resolution_disputed' type='checkbox' value='1' class='form-check-input' %s>",
+                                'value' => $result['resolution_disputed'],
+                                'query' => null
+                            ],
+                            'structural' => [
+                                'label' => "<label for='structural' class='form-check-label check-label-left'>Stuctural</label>",
+                                'tagName' => 'input',
+                                'type' => 'checkbox',
+                                'element' => "<input name='structural' id='structural' type='checkbox' value='1' class='form-check-input' %s>",
+                                'value' => $result['structural'],
+                                'query' => null
+                            ]
+                        ]
+                    ]
                 ]
             ];
         
             $bartFields = [
-                'id_bart' => [
-                    sprintf($labelStr, 'id_bart', $required, 'BART ID')
-                    ."<input name='id_bart' id='id_bart' type='text' value='{$result['id_bart']}' class='form-control' required>"
+                'row1' => [
+                    'id_bart' => [
+                        'label' => returnLabel('id_bart', 'BART ID', 'required'),
+                        'tagName' => 'input',
+                        'type' => 'text',
+                        'element' => "<input name='id_bart' id='id_bart' type='text' value='%s' class='form-control' required>",
+                        'value' => $result['id_bart']
+                    ]
                 ],
-                'description_bart' => [
-                    sprintf($labelStr, 'description_bart', $required, 'Description')
-                    ."<textarea name='description_bart' id='description_bart' maxlength='1000' class='form-control' required>".stripcslashes($result['description_bart'])."</textarea>"
+                'row2' => [
+                    'description_bart' => [
+                        'label' => returnLabel('description_bart', 'Description', 1),
+                        'tagName' => 'textarea',
+                        'element' => "<textarea name='description_bart' id='description_bart' maxlength='1000' class='form-control' required>%s</textarea>",
+                        'value' => stripcslashes($result['description_bart'])
+                    ]
                 ],
-                [
-                    returnRow([
-                        sprintf($labelStr, 'cat1_bart', '', 'Category 1'),
-                        "<input name='cat1_bart' id='cat1_bart' type='text' maxlength='3' value='".stripcslashes($result['cat1_bart'])."' class='form-control'>"
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'cat2_bart', '', 'Category 2'),
-                        "<input name='cat2_bart' id='cat2_bart' type='text' maxlength='3' value='".stripcslashes($result['cat2_bart'])."' class='form-control'>"
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'cat3_bart', '', 'Category 3'),
-                        "<input name='cat3_bart' id='cat3_bart' type='text' maxlength='3' value='".stripcslashes($result['cat3_bart'])."' class='form-control'>"
-                    ]),
-                    returnRow([
-                        sprintf($labelStr, 'level_bart', $required, 'Level'),
-                        'level_bart' => [
-                            'tagName' => 'select',
-                            'element' => "<select name='level_bart' id='level_bart' class='form-control' required>%s</select>",
-                            'value' => $result['level_bart'],
-                            'query' => [ 'PROGRAM', 'PROJECT' ]
-                        ]
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'dateOpen_bart', $required, 'Date open'),
-                        "<input name='dateOpen_bart' id='dateOpen_bart' type='date' value='{$result['dateOpen_bart']}' class='form-control' required>"
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'dateClose_bart', '', 'Date closed'),
-                        "<input name='dateClose_bart' id='dateClose_bart' type='date' value='{$result['dateClose_bart']}' class='form-control'>"
-                    ]).
-                    returnRow([
-                        sprintf($labelStr, 'status_bart', $required, 'Status'),
+                'row3' => [
+                    'options' => [ 'inline' => true ],
+                    'col1' => [
+                        // 'options' => [ 'inline' => true ],
                         [
-                            'tagName' => 'select',
-                            'element' => "<select name='status_bart' id='status_bart' class='form-control' required>%s</select>",
-                            'value' => $result['status_bart'],
-                            'query' => "SELECT statusID, status from Status WHERE status <> 'Deleted'"
+                            [
+                                'label' => returnLabel('cat1_bart', 'Category 1'),
+                                'tagName' => 'input',
+                                'type' => 'text',
+                                'element' => "<input name='cat1_bart' id='cat1_bart' type='text' maxlength='3' value='%s' class='form-control'>",
+                                'value' => stripcslashes($result['cat1_bart'])
+                            ]
+                        ],
+                        [
+                            [
+                                'label' => returnLabel('cat2_bart', 'Category 2'),
+                                'tagName' => 'input',
+                                'type' => 'text',
+                                'element' => "<input name='cat2_bart' id='cat2_bart' type='text' maxlength='3' value='%s' class='form-control'>",
+                                'value' => stripcslashes($result['cat2_bart'])
+                            ]
+                        ],
+                        [
+                            [
+                                'label' => returnLabel('cat3_bart', 'Category 3'),
+                                'tagName' => 'input',
+                                'type' => 'text',
+                                'element' => "<input name='cat3_bart' id='cat3_bart' type='text' maxlength='3' value='%s' class='form-control'>",
+                                'value' => stripcslashes($result['cat3_bart'])
+                            ]
                         ]
-                    ])
+                    ],
+                    'col2' => [
+                        // 'options' => [ 'inline' => true ],
+                        [
+                            'level_bart' => [
+                                'label' => returnLabel('level_bart', 'Level', true),
+                                'tagName' => 'select',
+                                'element' => "<select name='level_bart' id='level_bart' class='form-control' required>%s</select>",
+                                'value' => $result['level_bart'],
+                                'query' => [ 'PROGRAM', 'PROJECT' ]
+                            ]
+                        ],
+                        [
+                            [
+                                'label' => returnLabel('dateOpen_bart', 'Date open', 1),
+                                'tagName' => 'input',
+                                'type' => 'date',
+                                'element' => "<input name='dateOpen_bart' id='dateOpen_bart' type='date' value='%s' class='form-control' required>",
+                                'value' => $result['dateOpen_bart']
+                            ]
+                        ],
+                        [
+                            [
+                                'label' => returnLabel('dateClose_bart', 'Date closed'),
+                                'tagName' => 'input',
+                                'type' => 'date',
+                                'value' => $result['dateClose_bart'],
+                                'element' => "<input name='dateClose_bart' id='dateClose_bart' type='date' value='%s' class='form-control'>"
+                            ]
+                        ],
+                        [
+                            [
+                                'label' => returnLabel('status_bart', 'Status', 1),
+                                'tagName' => 'select',
+                                'element' => "<select name='status_bart' id='status_bart' class='form-control' required>%s</select>",
+                                'value' => $result['status_bart'],
+                                'query' => "SELECT statusID, status from Status WHERE status <> 'Deleted'"
+                            ]
+                        ]
+                    ]
                 ]
             ];
             echo "

--- a/utils/utils.php
+++ b/utils/utils.php
@@ -2,4 +2,11 @@
 function boolToStr($bool) {
     return ($bool ? 'true' : 'false');
 }
+
+function isHtmlStr(string $str) {
+    /* '/(?<=<)\w+(?=[^<]*?>)/'
+    ** "/(?<=<)\w+(?=[^<]*?>)/"
+    ** '/<\s?[^\>]*\/?\s?>/i'
+    */
+}
 ?>


### PR DESCRIPTION
…r rows/cols (#114)

* feat: add and view comments for BART defs (#111)

* add comments feed to bottom of View

* add new comment on Update form

* use flex space-between for bart comment byline

* add new comment from New Bart Def form

* show comment list on Update form and adjust timestamp to local time

* show correct fields for BART in DisplayDefs

* put Location redirects back in before merge

* take vta fields out of returnRow fn and put them in plain arrays in updateBartDef

* use sprintf to return row string

* add extra col wd onto last col in row

* factor out isFormCtrl into its own fcn

* if collection of elementArrays passed to returnCol, iterate, passing each to returnRow

* add offset option back into returnCol

* one fcn to pass all ViewDef rowGroups to returnRow

* pass inline option on collection of cols

* unstringify all elements in updateBartDef and put them in arrays

* ok now unstringinfy all updateBartDef elements for real

* add a condition for inline checkboxes

* add a class for when inline checkbox labels are on the left side

* copy-paste checkbox row from updateBart to newBart

* check isset($element[inline]) before checking its boolean value

* fix one field mapping and error handling in NewDef and RecDef